### PR TITLE
Add check to find gaps during day which start outside sunrise or sunset #39

### DIFF
--- a/postgresql/htw_pv3_postgresql_07_data_analysis.sql
+++ b/postgresql/htw_pv3_postgresql_07_data_analysis.sql
@@ -222,6 +222,7 @@ UPDATE pv3.pv3_related_gaps AS g
 
 UPDATE pv3.pv3_related_gaps AS g
     SET     during_day = CASE
+        WHEN ts_start::time < sunset AND ts_end::time > sunrise THEN 'TRUE'
         WHEN ts_start::time < sunrise OR ts_end::time > sunset THEN 'FALSE'
         ELSE 'TRUE'
         END;

--- a/postgresql/htw_pv3_postgresql_07_data_analysis_01.sql
+++ b/postgresql/htw_pv3_postgresql_07_data_analysis_01.sql
@@ -208,6 +208,7 @@ UPDATE pv3.pv3_related_gaps AS g
 
 UPDATE pv3.pv3_related_gaps AS g
     SET     during_day = CASE
+        WHEN ts_start::time < sunset AND ts_end::time > sunrise THEN 'TRUE'
         WHEN ts_start::time < sunrise OR ts_end::time > sunset THEN 'FALSE'
         ELSE 'TRUE'
         END;


### PR DESCRIPTION
The Data Gaps that started before sunrise and continued after sunrise were not found. I added a seperate check that fixed the issue and is now able to find all gaps.
Close #39 